### PR TITLE
fix fetchurl dependency for knownrockspec

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,12 @@
+name: "Test nix unstable"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: cachix/install-nix-action@v22
+    - run: nix build
+    - run: result/bin/luarocks nix lua-iconv

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center"><a href="http://luarocks.org"><img border="0" src="http://luarocks.github.io/luarocks/luarocks.png" alt="LuaRocks" width="500px"></a></p>
 
+This is a fork that adds a "nix" command to generate nix packages from
+rockspecs.
+You can test the fork with `luarocks nix <PACKAGE>`, e.g., `luarocks nix date`.
+
 A package manager for Lua modules.
 
 [![Build Status](https://github.com/luarocks/luarocks/actions/workflows/test.yml/badge.svg)](https://github.com/luarocks/luarocks/actions)

--- a/src/luarocks/cmd/nix.lua
+++ b/src/luarocks/cmd/nix.lua
@@ -298,8 +298,12 @@ local function convert_spec2nix(spec, rockspec_relpath, rockspec_url, manual_ove
    local fetchDeps, src_str
    if rockspec_url then
      -- sources = "src = "..gen_src_from_basic_url(rock_url)..";"
-     _, src_str = url2src(rockspec_url)
-      rockspec_str = [[  knownRockspec = (]]..src_str..[[).outPath;]]
+     fetchDeps , src_str = url2src(rockspec_url)
+     rockspec_str = [[  knownRockspec = (]]..src_str..[[).outPath;]]
+     if fetchDeps ~= nil then
+      call_package_inputs[fetchDeps]=2
+     end
+
    end
 
    -- we have to embed the valid rockspec since most repos dont contain
@@ -517,14 +521,13 @@ function nix.command(args)
       end
 
       if not current_candidate then
-         local err = "can't find a valid candidate "
+         err = "can't find a valid candidate "
          util.printerr(err)
          -- return nil, err
          return
       end
       -- local fetch_git = require("luarocks.fetch.git")
       debug("loading rockspec ", rockspec_filename)
-      local err
       spec, err = fetch.load_local_rockspec(rockspec_filename, nil)
       if not spec then
          return nil, err

--- a/src/luarocks/cmd/nix.lua
+++ b/src/luarocks/cmd/nix.lua
@@ -366,7 +366,10 @@ local function convert_spec2nix(spec, rockspec_relpath, rockspec_url, manual_ove
 
    -- should be able to do without 'rec'
    -- we have to quote the urls because some finish with the bookmark '#' which fails with nix
-   local call_package_str = table.concat(util.keys(call_package_inputs), ", ")
+   local call_package_input_names = util.keys(call_package_inputs)
+   table.sort(call_package_input_names)
+
+   local call_package_str = table.concat(call_package_input_names, ", ")
    local header = [[
 { ]]..call_package_str..[[ }:
 buildLuarocksPackage {


### PR DESCRIPTION
previously it would ignore the fetcher used for knownrockspec, typically
"fetchurl" would not be in the callPackage arglist.

This was visible with these calls for instance:
luarocks nix etlua
luarocks nix datepreviously it would ignore the fetcher used for knownrockspec, typically
"fetchurl" would not be in the callPackage arglist.

This was visible with these calls for instance:
luarocks nix etlua
luarocks nix date